### PR TITLE
Rebuild Statistics page

### DIFF
--- a/server/user_routes.py
+++ b/server/user_routes.py
@@ -1,12 +1,16 @@
 from flask import Blueprint, request, jsonify, g
 from database import users_collection
-from datetime import datetime
+from datetime import datetime, timezone
 from groq import Groq
 from auth import requires_auth
 import os
 import random
 
 user_bp = Blueprint("user_bp", __name__)
+
+
+def _utc_now_iso():
+    return datetime.now(timezone.utc).isoformat()
 
 # Default categories for new users
 DEFAULT_PHONEMES = ["l", "r", "s", "th", "ch", "sh"]  # add more as needed
@@ -69,7 +73,8 @@ def adduser():
                 "a", "e", "i", "o", "u"]
     phoneme_scores = [{"phoneme": ph, "avgScore": None, "attempts": None} for ph in phonemes]
     initial_history = {ph: 0 for ph in phonemes}
-    
+    initial_history["timestamp"] = _utc_now_iso()
+
     user_doc = {
         "userId": user_id,
         "name": name,
@@ -237,50 +242,67 @@ def get_user_progress():
         "history": user["history"],
     })
 
+def _phoneme_for_lesson(lessons, lesson_id):
+    for lesson in lessons:
+        if lesson["id"] == lesson_id:
+            return lesson["phoneme"]
+    return "r"
+
+
+def _bumped_phoneme_scores(scores, phoneme, add_score):
+    for entry in scores:
+        if entry["phoneme"] != phoneme:
+            continue
+        prev_avg = entry["avgScore"] or 0
+        prev_attempts = entry["attempts"] or 0
+        entry["avgScore"] = (prev_avg * prev_attempts + add_score) / (prev_attempts + 1)
+        entry["attempts"] = prev_attempts + 1
+        break
+    return scores
+
+
+def _stamp_word_scores(word_scores, now_iso):
+    return [
+        {"word": w["word"], "score": w["score"], "timestamp": w.get("timestamp", now_iso)}
+        for w in word_scores
+        if "word" in w and "score" in w
+    ]
+
+
 @user_bp.route("/api/user/updateUserProgress", methods=["POST"])
 def update_user_progress():
-    data = request.get_json()
+    data = request.get_json() or {}
     user_id = data.get("userId")
     lesson_id = data.get("lessonId")
-    add_score = data.get("addScore")
+    add_score = data.get("addScore", 0)
+    incoming_word_scores = data.get("wordScores", [])
+
     user = users_collection.find_one({"userId": user_id})
     if not user:
         return jsonify({"message": "User not found"}), 404
 
-    prev_data = users_collection.find_one({"userId": user_id})
-    lessons_data = prev_data["lessons"]
-    phoneme = "r"
-    for i in range(len(lessons_data)):
-        if lessons_data[i]["id"] == lesson_id:
-            phoneme = lessons_data[i]["phoneme"]
-            break
-    # Update progress
-    updated_progress = prev_data["progress"]["phonemeScores"]
-    for i in range(len(updated_progress)):
-        if updated_progress[i]["phoneme"] == phoneme:
-            prev_avg = updated_progress[i]["avgScore"] or 0
-            prev_attempts = updated_progress[i]["attempts"] or 0
-            new_avg = (prev_avg * prev_attempts + add_score) / (prev_attempts + 1)
-            updated_progress[i]["avgScore"] = new_avg
-            updated_progress[i]["attempts"] = prev_attempts + 1
-            break
-    progress_update = {
-        "phonemeScores": updated_progress
-    }
-    prev_history = prev_data["history"][-1]
-    updated_history = prev_history.copy()
-    updated_history[phoneme] += add_score
+    now_iso = _utc_now_iso()
+    phoneme = _phoneme_for_lesson(user["lessons"], lesson_id)
+    phoneme_scores = _bumped_phoneme_scores(user["progress"]["phonemeScores"], phoneme, add_score)
+    new_word_scores = _stamp_word_scores(incoming_word_scores, now_iso)
+
+    new_history_entry = (user["history"][-1] if user.get("history") else {}).copy()
+    new_history_entry.pop("timestamp", None)
+    new_history_entry[phoneme] = new_history_entry.get(phoneme, 0) + add_score
+    new_history_entry["timestamp"] = now_iso
 
     users_collection.update_one(
         {"userId": user_id, "lessons.id": lesson_id},
         {"$set": {"lessons.$.score": add_score}}
     )
-
     users_collection.update_one(
         {"userId": user_id},
         {
-            "$set": {"progress": progress_update},
-            "$push": {"history": updated_history}
+            "$set": {"progress.phonemeScores": phoneme_scores},
+            "$push": {
+                "history": new_history_entry,
+                "progress.wordScores": {"$each": new_word_scores}
+            }
         }
     )
 

--- a/talky-app/src/Lesson/Lesson.jsx
+++ b/talky-app/src/Lesson/Lesson.jsx
@@ -7,6 +7,16 @@ import { useMatch } from 'react-router-dom';
 
 useGLTF.preload('/robot-draco.glb')
 
+function extractWordScores(res) {
+  if (!Array.isArray(res)) return [];
+  const now = new Date().toISOString();
+  return res.map(({ word, phonemes }) => {
+    const valid = (phonemes || []).map(p => p.score).filter(s => s != null);
+    const avg = valid.length ? valid.reduce((a, b) => a + b, 0) / valid.length : 0;
+    return { word, score: avg, timestamp: now };
+  });
+}
+
 const Model = forwardRef(function Model(props, ref) {
   const { scene, animations } = useGLTF('/robot-draco.glb');
   const robot = scene.getObjectByName('Robot');
@@ -59,6 +69,7 @@ export default function Lesson() {
   const [wordsToIPA, setWordsToIPA] = useState(null);
   const [currentWordsToIPA, setCurrentWordsToIPA] = useState(null);
   const [returnedWordsToIPA, setReturnedWordsToIPA] = useState(null);
+  const wordScoresRef = useRef([]);
 
   const toEmbed = (u) => {
     try {
@@ -133,6 +144,7 @@ export default function Lesson() {
       })));
       setCurrentWordsToIPA(wordsToIPA[currentSentenceIndex - 1] || null);
       if (data.passed) {
+        wordScoresRef.current.push(...extractWordScores(data.res));
         actions?.ThumbsUp?.play?.();
         const utter = new SpeechSynthesisUtterance("Great job!");
         setScore(score => (score ?? 0) + data.score);
@@ -206,7 +218,8 @@ export default function Lesson() {
         body: JSON.stringify({
           userId: userId,
           lessonId: currentLessonId,
-          addScore: (score / 700) || 0.1
+          addScore: (score / 700) || 0.1,
+          wordScores: wordScoresRef.current
         })
       }).catch(err => console.error('Failed to update user progress:', err));
       

--- a/talky-app/src/Statistics/Statistics.jsx
+++ b/talky-app/src/Statistics/Statistics.jsx
@@ -1,185 +1,130 @@
-import { useEffect, useState } from 'react';
-import { LineChart, BarChart, RadialGauge } from 'reaviz';
+import { useEffect, useMemo, useState } from 'react';
+
 import Header from '../Header/Header.jsx';
 import Footer from '../Footer.jsx';
 
-export default function Statistics(){
-    const [data, setData] = useState([]);
-    const [barData, setBarData] = useState([]);
-    const [phonemes, setPhonemes] = useState([]);
-    const [levelData, setLevelData] = useState([{key: 'level', data: 0}]);
-    const [selectedPhoneme, setSelectedPhoneme] = useState('');
-    const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+import { useStatsData } from './useStatsData.js';
+import {
+  activityCells,
+  computeStreak,
+  hardestWords,
+  mostImprovedWords,
+  progressSeries,
+  recentAttempts,
+} from './derive.js';
+import {
+  Card,
+  Heatmap,
+  LevelTile,
+  PhonemeGrid,
+  ProgressChart,
+  StreakTile,
+  WordList,
+} from './components.jsx';
 
-    useEffect(() => {
-        const userId = localStorage.getItem('userId') || 'demo';
-        console.log("userid", userId);
-        fetch(`${API_BASE}/api/user/progress?user_id=${encodeURIComponent(userId)}`)
-            .then(r => r.json())
-            .then(d => {
-                const scores = d.phonemeScores || [];
-                // extract unique phonemes
-                const uniquePhonemes = [...new Set(scores.map(s => s.phoneme))];
-                setPhonemes(uniquePhonemes);
-                if (uniquePhonemes.length > 0 && !selectedPhoneme) {
-                    setSelectedPhoneme(uniquePhonemes[0]);
-                }
-                // bar chart data: avgScore per phoneme
-                const barChartData = scores.map(s => ({
-                    key: s.phoneme,
-                    data: s.avgScore ?? 0
-                }));
-                setBarData(barChartData);
-            })
-            .catch(err => console.error(err));
-    }, []);
+const getUserId = () => localStorage.getItem('userId') || 'demo';
 
-    useEffect(() => {
-        const userId = localStorage.getItem('userId') || 'demo';
-        fetch(`${API_BASE}/api/user/get_level?user_id=${encodeURIComponent(userId)}`)
-            .then(r => r.json())
-            .then(d => {
-                console.log("User level data:", d);
-                const parsed = typeof d === 'string' ? JSON.parse(d) : d;
-                const points = parsed.level?.subpoints ?? 0;
-                setLevelData([{key: 'level', data: points}]);
-            })
-            .catch(err => console.error(err));
-    }, []);
-        
-    useEffect(() => {
-        if (!selectedPhoneme) return;
-        const userId = localStorage.getItem('userId') || 'demo';
-        fetch(`${API_BASE}/api/user/progress?user_id=${encodeURIComponent(userId)}`)
-            .then(r => r.json())
-            .then(d => {
-                const scores = d.phonemeScores || [];
-                const filtered = scores.filter(s => s.phoneme === selectedPhoneme);
-                const last14 = filtered.slice(-14);
-                const filled = [...Array(14 - last14.length).fill(null), ...last14];
-                const chartData = filled.map((item, i) => ({
-                    key: i,
-                    data: item?.avgScore ?? 1
-                }));
-                console.log(chartData);
-                setData(chartData);
-            })
-            .catch(err => console.error(err));
-    }, [selectedPhoneme]);
+const Layout = ({ children }) => (
+  <div className="min-h-screen bg-n-8 text-n-1">
+    <Header />
+    <main className="pt-32 pb-24 px-5 lg:px-10">
+      <div className="max-w-[87.5rem] mx-auto">{children}</div>
+    </main>
+    <Footer />
+  </div>
+);
 
+const PageHeading = () => (
+  <header className="mb-10">
+    <p className="tagline text-color-1">Statistics</p>
+    <h1 className="h2 mt-2 text-n-1">Your progress</h1>
+    <p className="body-2 mt-3 text-n-3 max-w-xl">
+      Track your speech journey, daily streaks, and the sounds and words you’re mastering.
+    </p>
+  </header>
+);
+
+const formatPercent = ({ value }) => `${Math.round(value * 100)}% avg`;
+const formatDelta = ({ value }) => `+${Math.round(value * 100)}%`;
+const formatDate = ({ timestamp }) => new Date(timestamp).toLocaleDateString();
+
+export default function Statistics() {
+  const { status, user, level, error } = useStatsData(getUserId());
+  const [selected, setSelected] = useState('');
+
+  const phonemes = user?.progress?.phonemeScores ?? [];
+  const wordScores = user?.progress?.wordScores ?? [];
+  const history = user?.history ?? [];
+
+  useEffect(() => {
+    if (phonemes.length && !selected) setSelected(phonemes[0].phoneme);
+  }, [phonemes, selected]);
+
+  const streak = useMemo(() => computeStreak(history), [history]);
+  const cells = useMemo(() => activityCells(history), [history]);
+  const series = useMemo(() => progressSeries(history, selected), [history, selected]);
+  const hardest = useMemo(() => hardestWords(wordScores), [wordScores]);
+  const improved = useMemo(() => mostImprovedWords(wordScores), [wordScores]);
+  const recent = useMemo(() => recentAttempts(wordScores), [wordScores]);
+
+  if (status === 'loading') {
+    return <Layout><Card>Loading statistics…</Card></Layout>;
+  }
+  if (status === 'error') {
     return (
-        <div style={{ position: 'fixed', inset: 0, flexDirection: 'column', height: '100vh', overflow: 'hidden' }}>
-            <Header />
-            <div style={{ 
-                flex: 1, 
-                height: '100vh',
-                display: 'flex',
-                padding: '130px',
-                overflow: 'hidden',
-                boxSizing: 'border-box',
-                gap: 32,
-                alignItems: 'flex-start'
-            }}>
-                {/* Left column - smaller charts */}
-                <div style={{ 
-                    flex: '0 0 400px',
-                    display: 'flex',
-                    flexDirection: 'column',
-                    gap: 32
-                }}>
-                    {/* Level gauge */}
-                    <div style={{
-                        padding: 12,
-                        borderRadius: 16,
-                        background: 'rgba(255, 255, 255, 0.9)',
-                        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
-                        backdropFilter: 'blur(10px)'
-                    }}>
-                        <h2 style={{ 
-                            margin: '0 0 8px 0',
-                            fontSize: '1.5rem',
-                            background: 'linear-gradient(90deg, #6dd3ff 0%, #6b73ff 100%)',
-                            WebkitBackgroundClip: 'text',
-                            WebkitTextFillColor: 'transparent',
-                            fontWeight: 700
-                        }}>
-                            Current Level
-                        </h2>
-                        <div style={{ display: 'flex', justifyContent: 'center' }}>
-                            <RadialGauge height={200} width={200} data={levelData} />
-                        </div>
-                    </div>
-
-                    {/* Average Score per Phoneme */}
-                    <div style={{
-                        padding: 24,
-                        borderRadius: 16,
-                        background: 'rgba(255, 255, 255, 0.9)',
-                        boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
-                        backdropFilter: 'blur(10px)',
-                        display: 'flex',
-                        flexDirection: 'column',
-                    }}>
-                        <h2 style={{ 
-                            margin: '0 0 16px 0',
-                            fontSize: '1.5rem',
-                            background: 'linear-gradient(90deg, #6dd3ff 0%, #6b73ff 100%)',
-                            WebkitBackgroundClip: 'text',
-                            WebkitTextFillColor: 'transparent',
-                            fontWeight: 700
-                        }}>
-                            Average Score per Phoneme
-                        </h2>
-                        <BarChart width={350} height={250} data={barData} />
-                    </div>
-                </div>
-
-                {/* Right column - main chart */}
-                <div style={{ 
-                    flex: 1,
-                    padding: 24,
-                    borderRadius: 16,
-                    background: 'rgba(255, 255, 255, 0.9)',
-                    boxShadow: '0 8px 32px rgba(0, 0, 0, 0.1)',
-                    backdropFilter: 'blur(10px)'
-                }}>
-                    <h2 style={{ 
-                        margin: '0 0 16px 0',
-                        fontSize: '2rem',
-                        background: 'linear-gradient(90deg, #6dd3ff 0%, #6b73ff 100%)',
-                        WebkitBackgroundClip: 'text',
-                        WebkitTextFillColor: 'transparent',
-                        fontWeight: 700
-                    }}>
-                        Phoneme Score Progress (Last 14)
-                    </h2>
-                    <select
-                        value={selectedPhoneme}
-                        onChange={(e) => setSelectedPhoneme(e.target.value)}
-                        style={{
-                            padding: '10px 16px',
-                            borderRadius: 8,
-                            border: 'none',
-                            background: 'linear-gradient(90deg, #6dd3ff 0%, #6b73ff 100%)',
-                            color: 'white',
-                            fontWeight: 600,
-                            cursor: 'pointer',
-                            marginBottom: 24,
-                            minWidth: 200,
-                            fontSize: '1rem',
-                            boxShadow: '0 4px 12px rgba(107, 115, 255, 0.3)'
-                        }}
-                    >
-                        {phonemes.map(p => (
-                            <option key={p} value={p} style={{ background: 'white', color: '#333' }}>
-                                {p}
-                            </option>
-                        ))}
-                    </select>
-                    <LineChart width={700} height={470} data={data} />
-                </div>
-            </div>
-            <Footer />
-        </div>
+      <Layout>
+        <Card title="Couldn’t load statistics">
+          <p className="body-2 text-n-3">{String(error?.message ?? error)}</p>
+        </Card>
+      </Layout>
     );
-};
+  }
+
+  return (
+    <Layout>
+      <PageHeading />
+
+      <div className="flex flex-col gap-6">
+        <div className="grid gap-6 lg:grid-cols-[260px_260px_1fr]">
+          <LevelTile level={level} />
+          <StreakTile streak={streak} />
+          <Heatmap cells={cells} />
+        </div>
+
+        <ProgressChart
+          phonemes={phonemes}
+          selected={selected}
+          onSelect={setSelected}
+          series={series}
+        />
+
+        <div className="grid gap-6 lg:grid-cols-[1fr_2fr] items-start">
+          <div className="flex flex-col gap-6">
+            <WordList
+              title="Needs practice"
+              rows={hardest}
+              empty="Complete a few words to see the trickiest ones."
+              valueClass="text-color-3"
+              format={formatPercent}
+            />
+            <WordList
+              title="Most improved"
+              rows={improved}
+              empty="Practice each word a couple of times to track improvement."
+              valueClass="text-color-4"
+              format={formatDelta}
+            />
+            <WordList
+              title="Recent attempts"
+              rows={recent}
+              empty="No recent attempts yet."
+              valueClass="text-n-3"
+              format={formatDate}
+            />
+          </div>
+          <PhonemeGrid scores={phonemes} />
+        </div>
+      </div>
+    </Layout>
+  );
+}

--- a/talky-app/src/Statistics/Statistics.jsx
+++ b/talky-app/src/Statistics/Statistics.jsx
@@ -8,18 +8,21 @@ import {
   activityCells,
   computeStreak,
   hardestWords,
+  masteryBars,
   mostImprovedWords,
+  overallAccuracy,
   progressSeries,
   recentAttempts,
+  totalAttempts,
 } from './derive.js';
 import {
   Card,
   Heatmap,
   LevelTile,
-  PhonemeGrid,
+  PhonemeMastery,
   ProgressChart,
-  StreakTile,
-  WordList,
+  StatTile,
+  WordTabs,
 } from './components.jsx';
 
 const getUserId = () => localStorage.getItem('userId') || 'demo';
@@ -39,14 +42,16 @@ const PageHeading = () => (
     <p className="tagline text-color-1">Statistics</p>
     <h1 className="h2 mt-2 text-n-1">Your progress</h1>
     <p className="body-2 mt-3 text-n-3 max-w-xl">
-      Track your speech journey, daily streaks, and the sounds and words you’re mastering.
+      A snapshot of your streaks, sounds, and the words you’re mastering.
     </p>
   </header>
 );
 
-const formatPercent = ({ value }) => `${Math.round(value * 100)}% avg`;
-const formatDelta = ({ value }) => `+${Math.round(value * 100)}%`;
-const formatDate = ({ timestamp }) => new Date(timestamp).toLocaleDateString();
+const streakSub = (streak) => {
+  if (streak === 0) return 'Start a lesson today';
+  if (streak === 1) return 'Great start — come back tomorrow';
+  return 'Keep the momentum going';
+};
 
 export default function Statistics() {
   const { status, user, level, error } = useStatsData(getUserId());
@@ -55,17 +60,24 @@ export default function Statistics() {
   const phonemes = user?.progress?.phonemeScores ?? [];
   const wordScores = user?.progress?.wordScores ?? [];
   const history = user?.history ?? [];
+  const playablePhonemes = phonemes.filter((p) => p.attempts > 0);
 
   useEffect(() => {
-    if (phonemes.length && !selected) setSelected(phonemes[0].phoneme);
-  }, [phonemes, selected]);
+    if (playablePhonemes.length && !selected) {
+      setSelected(playablePhonemes[0].phoneme);
+    }
+  }, [playablePhonemes, selected]);
 
   const streak = useMemo(() => computeStreak(history), [history]);
   const cells = useMemo(() => activityCells(history), [history]);
   const series = useMemo(() => progressSeries(history, selected), [history, selected]);
+  const bars = useMemo(() => masteryBars(phonemes), [phonemes]);
   const hardest = useMemo(() => hardestWords(wordScores), [wordScores]);
   const improved = useMemo(() => mostImprovedWords(wordScores), [wordScores]);
   const recent = useMemo(() => recentAttempts(wordScores), [wordScores]);
+
+  const total = useMemo(() => totalAttempts(phonemes), [phonemes]);
+  const accuracy = useMemo(() => overallAccuracy(phonemes), [phonemes]);
 
   if (status === 'loading') {
     return <Layout><Card>Loading statistics…</Card></Layout>;
@@ -85,45 +97,41 @@ export default function Statistics() {
       <PageHeading />
 
       <div className="flex flex-col gap-6">
-        <div className="grid gap-6 lg:grid-cols-[260px_260px_1fr]">
+        <div className="grid gap-6 grid-cols-2 lg:grid-cols-4">
           <LevelTile level={level} />
-          <StreakTile streak={streak} />
-          <Heatmap cells={cells} />
+          <StatTile
+            label="Day streak"
+            value={streak}
+            sub={streakSub(streak)}
+            accent="text-color-2"
+          />
+          <StatTile
+            label="Overall accuracy"
+            value={accuracy == null ? '—' : `${Math.round(accuracy * 100)}%`}
+            sub={accuracy == null ? 'No attempts yet' : 'Across all sounds'}
+            accent="text-color-4"
+          />
+          <StatTile
+            label="Total attempts"
+            value={total}
+            sub={total === 0 ? 'Try your first lesson' : 'Sound attempts logged'}
+            accent="text-color-5"
+          />
         </div>
 
-        <ProgressChart
-          phonemes={phonemes}
-          selected={selected}
-          onSelect={setSelected}
-          series={series}
-        />
+        <Heatmap cells={cells} />
 
-        <div className="grid gap-6 lg:grid-cols-[1fr_2fr] items-start">
-          <div className="flex flex-col gap-6">
-            <WordList
-              title="Needs practice"
-              rows={hardest}
-              empty="Complete a few words to see the trickiest ones."
-              valueClass="text-color-3"
-              format={formatPercent}
-            />
-            <WordList
-              title="Most improved"
-              rows={improved}
-              empty="Practice each word a couple of times to track improvement."
-              valueClass="text-color-4"
-              format={formatDelta}
-            />
-            <WordList
-              title="Recent attempts"
-              rows={recent}
-              empty="No recent attempts yet."
-              valueClass="text-n-3"
-              format={formatDate}
-            />
-          </div>
-          <PhonemeGrid scores={phonemes} />
+        <div className="grid gap-6 lg:grid-cols-[2fr_1fr] items-start">
+          <ProgressChart
+            phonemes={playablePhonemes}
+            selected={selected}
+            onSelect={setSelected}
+            series={series}
+          />
+          <PhonemeMastery bars={bars} />
         </div>
+
+        <WordTabs hardest={hardest} improved={improved} recent={recent} />
       </div>
     </Layout>
   );

--- a/talky-app/src/Statistics/components.jsx
+++ b/talky-app/src/Statistics/components.jsx
@@ -1,0 +1,144 @@
+import { LineChart, RadialGauge } from 'reaviz';
+import { HEATMAP_DAYS } from './derive.js';
+
+export const Card = ({ title, action, children, className = '' }) => (
+  <section className={`p-6 lg:p-8 bg-n-7 border border-n-1/10 rounded-3xl ${className}`}>
+    {(title || action) && (
+      <header className="flex items-center justify-between mb-5 gap-3 flex-wrap">
+        {title && <h3 className="h6 text-n-1 m-0">{title}</h3>}
+        {action}
+      </header>
+    )}
+    {children}
+  </section>
+);
+
+export const Empty = ({ children }) => (
+  <p className="body-2 text-n-4">{children}</p>
+);
+
+export const LevelTile = ({ level }) => (
+  <Card title="Current level" className="flex flex-col items-center">
+    <RadialGauge height={180} width={180} data={[{ key: 'level', data: level }]} />
+  </Card>
+);
+
+const streakMessage = (streak) => {
+  if (streak === 0) return 'Start a lesson today!';
+  if (streak === 1) return 'Great start — come back tomorrow.';
+  return 'Keep the momentum going!';
+};
+
+export const StreakTile = ({ streak }) => (
+  <Card title="Day streak" className="flex flex-col items-center justify-center text-center">
+    <div className="text-6xl font-semibold text-color-2 leading-none">{streak}</div>
+    <p className="mt-4 body-2 text-n-3">{streakMessage(streak)}</p>
+  </Card>
+);
+
+const intensityClass = (count) => {
+  if (count === 0) return 'bg-n-6';
+  if (count < 3) return 'bg-color-4/40';
+  if (count < 6) return 'bg-color-4/70';
+  return 'bg-color-4';
+};
+
+export const Heatmap = ({ cells }) => (
+  <Card title={`Activity · last ${HEATMAP_DAYS} days`} className="flex-1">
+    <div className="grid grid-rows-7 grid-flow-col gap-1.5 overflow-x-auto pb-1">
+      {cells.map((cell, i) =>
+        cell === null ? (
+          <div key={`pad-${i}`} className="w-3.5 h-3.5" aria-hidden />
+        ) : (
+          <div
+            key={cell.date}
+            title={`${cell.date}: ${cell.count} attempt${cell.count === 1 ? '' : 's'}`}
+            className={`w-3.5 h-3.5 rounded-[3px] ${intensityClass(cell.count)}`}
+          />
+        ),
+      )}
+    </div>
+  </Card>
+);
+
+export const ProgressChart = ({ phonemes, selected, onSelect, series }) => (
+  <Card
+    title="Progress over time"
+    action={
+      <select
+        value={selected}
+        onChange={(e) => onSelect(e.target.value)}
+        className="px-4 py-2 rounded-xl bg-n-6 border border-n-1/10 text-n-1 font-semibold focus:outline-none focus:border-color-1"
+        aria-label="Choose sound"
+      >
+        {phonemes.map((p) => (
+          <option key={p.phoneme} value={p.phoneme}>Sound: {p.phoneme}</option>
+        ))}
+      </select>
+    }
+  >
+    <div className="h-[320px]">
+      {series.length === 0 ? (
+        <div className="h-full flex items-center justify-center">
+          <Empty>No history yet for this sound.</Empty>
+        </div>
+      ) : (
+        <LineChart width="100%" height={320} data={series} />
+      )}
+    </div>
+  </Card>
+);
+
+export const PhonemeGrid = ({ scores }) => (
+  <Card title="Sound mastery">
+    <div className="grid grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-3">
+      {scores.map(({ phoneme, avgScore, attempts }) => {
+        const started = attempts > 0;
+        return (
+          <div
+            key={phoneme}
+            className={`p-4 rounded-2xl border text-center ${
+              started ? 'border-n-1/10 bg-n-6' : 'border-n-1/5 bg-n-8/60'
+            }`}
+          >
+            <div className={`text-2xl font-semibold ${started ? 'text-color-1' : 'text-n-4'}`}>
+              {phoneme}
+            </div>
+            {started ? (
+              <>
+                <div className="mt-1 text-lg font-semibold text-n-1">
+                  {Math.round((avgScore ?? 0) * 100)}%
+                </div>
+                <div className="mt-0.5 caption text-n-3">
+                  {attempts} attempt{attempts === 1 ? '' : 's'}
+                </div>
+              </>
+            ) : (
+              <div className="mt-1 caption text-n-4">Not started</div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  </Card>
+);
+
+export const WordList = ({ title, rows, empty, format, valueClass = 'text-n-1' }) => (
+  <Card title={title}>
+    {rows.length === 0 ? (
+      <Empty>{empty}</Empty>
+    ) : (
+      <ul className="divide-y divide-n-6">
+        {rows.map((row, i) => (
+          <li
+            key={`${row.word}-${i}`}
+            className="flex justify-between items-center py-3 first:pt-0 last:pb-0"
+          >
+            <span className="font-mono text-n-1">{row.word}</span>
+            <span className={`font-semibold ${valueClass}`}>{format(row)}</span>
+          </li>
+        ))}
+      </ul>
+    )}
+  </Card>
+);

--- a/talky-app/src/Statistics/components.jsx
+++ b/talky-app/src/Statistics/components.jsx
@@ -1,10 +1,20 @@
-import { LineChart, RadialGauge } from 'reaviz';
+import { useState } from 'react';
+import {
+  AreaChart,
+  AreaSeries,
+  Area,
+  Line,
+  BarList,
+  BarListSeries,
+} from 'reaviz';
 import { HEATMAP_DAYS } from './derive.js';
+
+const fmtPct = (v) => `${Math.round(v * 100)}%`;
 
 export const Card = ({ title, action, children, className = '' }) => (
   <section className={`p-6 lg:p-8 bg-n-7 border border-n-1/10 rounded-3xl ${className}`}>
     {(title || action) && (
-      <header className="flex items-center justify-between mb-5 gap-3 flex-wrap">
+      <header className="flex items-center justify-between gap-3 flex-wrap mb-5">
         {title && <h3 className="h6 text-n-1 m-0">{title}</h3>}
         {action}
       </header>
@@ -17,34 +27,56 @@ export const Empty = ({ children }) => (
   <p className="body-2 text-n-4">{children}</p>
 );
 
-export const LevelTile = ({ level }) => (
-  <Card title="Current level" className="flex flex-col items-center">
-    <RadialGauge height={180} width={180} data={[{ key: 'level', data: level }]} />
+export const StatTile = ({ label, value, sub, accent = 'text-n-1' }) => (
+  <Card className="flex flex-col gap-2 min-h-[140px] justify-center">
+    <p className="tagline text-n-3">{label}</p>
+    <p className={`text-4xl lg:text-5xl font-semibold leading-none ${accent}`}>{value}</p>
+    {sub && <p className="caption text-n-4">{sub}</p>}
   </Card>
 );
 
-const streakMessage = (streak) => {
-  if (streak === 0) return 'Start a lesson today!';
-  if (streak === 1) return 'Great start — come back tomorrow.';
-  return 'Keep the momentum going!';
+export const LevelTile = ({ level }) => {
+  const current = level?.current ?? 1;
+  const subpoints = level?.subpoints ?? 0;
+  const maxval = level?.maxval || 100;
+  const pct = Math.min(100, Math.round((subpoints / maxval) * 100));
+
+  return (
+    <Card className="flex flex-col gap-3 min-h-[140px] justify-center">
+      <div className="flex items-baseline justify-between gap-3">
+        <p className="tagline text-n-3">Level</p>
+        <p className="caption text-n-3">{subpoints} / {maxval} XP</p>
+      </div>
+      <p className="text-4xl lg:text-5xl font-semibold leading-none text-color-1">{current}</p>
+      <div className="h-2 rounded-full bg-n-6 overflow-hidden">
+        <div
+          className="h-full bg-color-1 transition-[width] duration-500"
+          style={{ width: `${pct}%` }}
+        />
+      </div>
+    </Card>
+  );
 };
-
-export const StreakTile = ({ streak }) => (
-  <Card title="Day streak" className="flex flex-col items-center justify-center text-center">
-    <div className="text-6xl font-semibold text-color-2 leading-none">{streak}</div>
-    <p className="mt-4 body-2 text-n-3">{streakMessage(streak)}</p>
-  </Card>
-);
 
 const intensityClass = (count) => {
   if (count === 0) return 'bg-n-6';
-  if (count < 3) return 'bg-color-4/40';
-  if (count < 6) return 'bg-color-4/70';
+  if (count < 3) return 'bg-color-4/30';
+  if (count < 6) return 'bg-color-4/60';
   return 'bg-color-4';
 };
 
+const Legend = () => (
+  <div className="flex items-center gap-2 mt-4 text-n-4 caption">
+    <span>Less</span>
+    {[0, 2, 5, 8].map((n) => (
+      <span key={n} className={`w-3 h-3 rounded-[3px] ${intensityClass(n)}`} aria-hidden />
+    ))}
+    <span>More</span>
+  </div>
+);
+
 export const Heatmap = ({ cells }) => (
-  <Card title={`Activity · last ${HEATMAP_DAYS} days`} className="flex-1">
+  <Card title={`Activity · last ${HEATMAP_DAYS} days`}>
     <div className="grid grid-rows-7 grid-flow-col gap-1.5 overflow-x-auto pb-1">
       {cells.map((cell, i) =>
         cell === null ? (
@@ -58,87 +90,124 @@ export const Heatmap = ({ cells }) => (
         ),
       )}
     </div>
+    <Legend />
   </Card>
 );
 
+const PhonemeChips = ({ phonemes, selected, onSelect }) => (
+  <div className="flex flex-wrap gap-2">
+    {phonemes.map((p) => {
+      const active = p.phoneme === selected;
+      return (
+        <button
+          key={p.phoneme}
+          type="button"
+          onClick={() => onSelect(p.phoneme)}
+          className={`px-3 py-1.5 rounded-full font-mono text-sm border transition-colors ${
+            active
+              ? 'bg-color-1 text-n-8 border-color-1'
+              : 'bg-n-6 text-n-2 border-n-1/10 hover:border-color-1/60'
+          }`}
+        >
+          {p.phoneme}
+        </button>
+      );
+    })}
+  </div>
+);
+
 export const ProgressChart = ({ phonemes, selected, onSelect, series }) => (
-  <Card
-    title="Progress over time"
-    action={
-      <select
-        value={selected}
-        onChange={(e) => onSelect(e.target.value)}
-        className="px-4 py-2 rounded-xl bg-n-6 border border-n-1/10 text-n-1 font-semibold focus:outline-none focus:border-color-1"
-        aria-label="Choose sound"
-      >
-        {phonemes.map((p) => (
-          <option key={p.phoneme} value={p.phoneme}>Sound: {p.phoneme}</option>
-        ))}
-      </select>
-    }
-  >
-    <div className="h-[320px]">
+  <Card title="Progress over time">
+    <PhonemeChips phonemes={phonemes} selected={selected} onSelect={onSelect} />
+    <div className="h-[280px] mt-5">
       {series.length === 0 ? (
         <div className="h-full flex items-center justify-center">
           <Empty>No history yet for this sound.</Empty>
         </div>
       ) : (
-        <LineChart width="100%" height={320} data={series} />
+        <AreaChart
+          height={280}
+          width={undefined}
+          data={series}
+          series={
+            <AreaSeries
+              area={<Area gradient={null} mask={null} />}
+              line={<Line strokeWidth={2} />}
+              colorScheme="#AC6AFF"
+              interpolation="smooth"
+            />
+          }
+        />
       )}
     </div>
   </Card>
 );
 
-export const PhonemeGrid = ({ scores }) => (
+export const PhonemeMastery = ({ bars }) => (
   <Card title="Sound mastery">
-    <div className="grid grid-cols-[repeat(auto-fill,minmax(110px,1fr))] gap-3">
-      {scores.map(({ phoneme, avgScore, attempts }) => {
-        const started = attempts > 0;
-        return (
-          <div
-            key={phoneme}
-            className={`p-4 rounded-2xl border text-center ${
-              started ? 'border-n-1/10 bg-n-6' : 'border-n-1/5 bg-n-8/60'
-            }`}
-          >
-            <div className={`text-2xl font-semibold ${started ? 'text-color-1' : 'text-n-4'}`}>
-              {phoneme}
-            </div>
-            {started ? (
-              <>
-                <div className="mt-1 text-lg font-semibold text-n-1">
-                  {Math.round((avgScore ?? 0) * 100)}%
-                </div>
-                <div className="mt-0.5 caption text-n-3">
-                  {attempts} attempt{attempts === 1 ? '' : 's'}
-                </div>
-              </>
-            ) : (
-              <div className="mt-1 caption text-n-4">Not started</div>
-            )}
-          </div>
-        );
-      })}
-    </div>
-  </Card>
-);
-
-export const WordList = ({ title, rows, empty, format, valueClass = 'text-n-1' }) => (
-  <Card title={title}>
-    {rows.length === 0 ? (
-      <Empty>{empty}</Empty>
+    {bars.length === 0 ? (
+      <Empty>Complete a lesson to start tracking sound mastery.</Empty>
     ) : (
-      <ul className="divide-y divide-n-6">
-        {rows.map((row, i) => (
-          <li
-            key={`${row.word}-${i}`}
-            className="flex justify-between items-center py-3 first:pt-0 last:pb-0"
-          >
-            <span className="font-mono text-n-1">{row.word}</span>
-            <span className={`font-semibold ${valueClass}`}>{format(row)}</span>
-          </li>
-        ))}
-      </ul>
+      <BarList
+        data={bars}
+        type="percent"
+        series={
+          <BarListSeries
+            colorScheme={['#FF776F', '#FFC876', '#7ADB78']}
+          />
+        }
+      />
     )}
   </Card>
 );
+
+const TAB_DEFS = [
+  { id: 'hardest', label: 'Needs practice', empty: 'Complete a few words to see the trickiest ones.', valueClass: 'text-color-3', format: (r) => `${fmtPct(r.value)} avg` },
+  { id: 'improved', label: 'Most improved', empty: 'Practice each word a couple of times to track improvement.', valueClass: 'text-color-4', format: (r) => `+${fmtPct(r.value)}` },
+  { id: 'recent', label: 'Recent', empty: 'No recent attempts yet.', valueClass: 'text-n-3', format: (r) => new Date(r.timestamp).toLocaleDateString() },
+];
+
+export const WordTabs = ({ hardest, improved, recent }) => {
+  const [tab, setTab] = useState('hardest');
+  const data = { hardest, improved, recent };
+  const active = TAB_DEFS.find((t) => t.id === tab);
+  const rows = data[tab];
+
+  return (
+    <Card
+      title="Word focus"
+      action={
+        <div className="flex gap-1 p-1 rounded-full bg-n-6 border border-n-1/10">
+          {TAB_DEFS.map((t) => (
+            <button
+              key={t.id}
+              type="button"
+              onClick={() => setTab(t.id)}
+              className={`px-3 py-1.5 rounded-full text-sm transition-colors ${
+                tab === t.id ? 'bg-n-8 text-n-1' : 'text-n-3 hover:text-n-1'
+              }`}
+            >
+              {t.label}
+            </button>
+          ))}
+        </div>
+      }
+    >
+      {rows.length === 0 ? (
+        <Empty>{active.empty}</Empty>
+      ) : (
+        <ul className="divide-y divide-n-6">
+          {rows.map((row, i) => (
+            <li
+              key={`${row.word}-${i}`}
+              className="flex justify-between items-center py-3 first:pt-0 last:pb-0"
+            >
+              <span className="font-mono text-n-1">{row.word}</span>
+              <span className={`font-semibold ${active.valueClass}`}>{active.format(row)}</span>
+            </li>
+          ))}
+        </ul>
+      )}
+    </Card>
+  );
+};

--- a/talky-app/src/Statistics/derive.js
+++ b/talky-app/src/Statistics/derive.js
@@ -1,7 +1,4 @@
-// Pure data shaping for the Statistics page.
-// No React, no fetch — safe to unit-test in isolation.
-
-export const HEATMAP_DAYS = 60;
+export const HEATMAP_DAYS = 91;
 export const WORD_LIST_LIMIT = 5;
 export const RECENT_LIMIT = 10;
 export const MIN_ATTEMPTS_FOR_RANKING = 2;
@@ -10,10 +7,10 @@ const MS_PER_DAY = 86_400_000;
 const dayKey = (iso) => iso.slice(0, 10);
 const daysBetween = (a, b) => Math.floor((a - b) / MS_PER_DAY);
 
-const stampedHistory = (history) => history.filter((h) => h.timestamp);
+const stamped = (history) => history.filter((h) => h?.timestamp);
 
 export function uniqueActiveDays(history) {
-  const set = new Set(stampedHistory(history).map((h) => dayKey(h.timestamp)));
+  const set = new Set(stamped(history).map((h) => dayKey(h.timestamp)));
   return [...set].sort().reverse();
 }
 
@@ -31,7 +28,7 @@ export function computeStreak(history, today = new Date()) {
 
 export function activityCells(history, days = HEATMAP_DAYS, today = new Date()) {
   const counts = new Map();
-  for (const h of stampedHistory(history)) {
+  for (const h of stamped(history)) {
     const key = dayKey(h.timestamp);
     counts.set(key, (counts.get(key) || 0) + 1);
   }
@@ -53,9 +50,19 @@ export function activityCells(history, days = HEATMAP_DAYS, today = new Date()) 
 
 export function progressSeries(history, phoneme) {
   if (!phoneme) return [];
-  return stampedHistory(history)
-    .filter((h) => h[phoneme] != null)
-    .map((h) => ({ key: new Date(h.timestamp), data: h[phoneme] }));
+  return stamped(history)
+    .map((h) => {
+      const value = h.phoneme === phoneme ? h.score : h[phoneme];
+      return value == null ? null : { key: new Date(h.timestamp), data: value };
+    })
+    .filter(Boolean);
+}
+
+export function masteryBars(phonemeScores) {
+  return phonemeScores
+    .filter((p) => p.attempts > 0 && p.avgScore != null)
+    .sort((a, b) => a.avgScore - b.avgScore)
+    .map((p) => ({ key: p.phoneme, data: Math.round(p.avgScore * 100) }));
 }
 
 function groupByWord(wordScores) {
@@ -105,4 +112,19 @@ export function recentAttempts(wordScores) {
     .filter((s) => s.timestamp)
     .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
     .slice(0, RECENT_LIMIT);
+}
+
+export function totalAttempts(phonemeScores) {
+  return phonemeScores.reduce((sum, p) => sum + (p.attempts || 0), 0);
+}
+
+export function overallAccuracy(phonemeScores) {
+  let weighted = 0;
+  let attempts = 0;
+  for (const p of phonemeScores) {
+    if (!p.attempts || p.avgScore == null) continue;
+    weighted += p.avgScore * p.attempts;
+    attempts += p.attempts;
+  }
+  return attempts === 0 ? null : weighted / attempts;
 }

--- a/talky-app/src/Statistics/derive.js
+++ b/talky-app/src/Statistics/derive.js
@@ -1,0 +1,108 @@
+// Pure data shaping for the Statistics page.
+// No React, no fetch — safe to unit-test in isolation.
+
+export const HEATMAP_DAYS = 60;
+export const WORD_LIST_LIMIT = 5;
+export const RECENT_LIMIT = 10;
+export const MIN_ATTEMPTS_FOR_RANKING = 2;
+
+const MS_PER_DAY = 86_400_000;
+const dayKey = (iso) => iso.slice(0, 10);
+const daysBetween = (a, b) => Math.floor((a - b) / MS_PER_DAY);
+
+const stampedHistory = (history) => history.filter((h) => h.timestamp);
+
+export function uniqueActiveDays(history) {
+  const set = new Set(stampedHistory(history).map((h) => dayKey(h.timestamp)));
+  return [...set].sort().reverse();
+}
+
+export function computeStreak(history, today = new Date()) {
+  const days = uniqueActiveDays(history);
+  let streak = 0;
+  let cursor = today;
+  for (const day of days) {
+    if (daysBetween(cursor, new Date(day)) > 1) break;
+    streak += 1;
+    cursor = new Date(day);
+  }
+  return streak;
+}
+
+export function activityCells(history, days = HEATMAP_DAYS, today = new Date()) {
+  const counts = new Map();
+  for (const h of stampedHistory(history)) {
+    const key = dayKey(h.timestamp);
+    counts.set(key, (counts.get(key) || 0) + 1);
+  }
+
+  const start = new Date(today);
+  start.setDate(start.getDate() - (days - 1));
+
+  const padStart = start.getDay();
+  const cells = Array.from({ length: padStart }, () => null);
+
+  for (let i = 0; i < days; i++) {
+    const d = new Date(start);
+    d.setDate(start.getDate() + i);
+    const key = d.toISOString().slice(0, 10);
+    cells.push({ date: key, count: counts.get(key) || 0 });
+  }
+  return cells;
+}
+
+export function progressSeries(history, phoneme) {
+  if (!phoneme) return [];
+  return stampedHistory(history)
+    .filter((h) => h[phoneme] != null)
+    .map((h) => ({ key: new Date(h.timestamp), data: h[phoneme] }));
+}
+
+function groupByWord(wordScores) {
+  const map = new Map();
+  for (const entry of wordScores) {
+    if (!entry?.word) continue;
+    const bucket = map.get(entry.word) ?? [];
+    bucket.push(entry);
+    map.set(entry.word, bucket);
+  }
+  return map;
+}
+
+const eligibleBuckets = (wordScores) =>
+  [...groupByWord(wordScores).values()].filter(
+    (bucket) => bucket.length >= MIN_ATTEMPTS_FOR_RANKING,
+  );
+
+const byTimestamp = (a, b) => new Date(a.timestamp) - new Date(b.timestamp);
+
+export function hardestWords(wordScores) {
+  return eligibleBuckets(wordScores)
+    .map((bucket) => ({
+      word: bucket[0].word,
+      value: bucket.reduce((sum, e) => sum + e.score, 0) / bucket.length,
+    }))
+    .sort((a, b) => a.value - b.value)
+    .slice(0, WORD_LIST_LIMIT);
+}
+
+export function mostImprovedWords(wordScores) {
+  return eligibleBuckets(wordScores)
+    .map((bucket) => {
+      const sorted = [...bucket].sort(byTimestamp);
+      return {
+        word: bucket[0].word,
+        value: sorted.at(-1).score - sorted[0].score,
+      };
+    })
+    .filter((w) => w.value > 0)
+    .sort((a, b) => b.value - a.value)
+    .slice(0, WORD_LIST_LIMIT);
+}
+
+export function recentAttempts(wordScores) {
+  return [...wordScores]
+    .filter((s) => s.timestamp)
+    .sort((a, b) => new Date(b.timestamp) - new Date(a.timestamp))
+    .slice(0, RECENT_LIMIT);
+}

--- a/talky-app/src/Statistics/useStatsData.js
+++ b/talky-app/src/Statistics/useStatsData.js
@@ -1,0 +1,49 @@
+import { useEffect, useState } from 'react';
+
+const API_BASE = import.meta.env.VITE_API_URL || 'http://localhost:8080';
+
+async function fetchJSON(url) {
+  const res = await fetch(url);
+  if (!res.ok) throw new Error(`${url} → HTTP ${res.status}`);
+  return res.json();
+}
+
+// Loads the full user document plus the level subpoints in parallel.
+// Returns { status, user, level, error } where status ∈ loading|ready|error.
+export function useStatsData(userId) {
+  const [state, setState] = useState({
+    status: 'loading',
+    user: null,
+    level: 0,
+    error: null,
+  });
+
+  useEffect(() => {
+    let cancelled = false;
+
+    Promise.all([
+      fetchJSON(`${API_BASE}/api/getUserProgress?userId=${encodeURIComponent(userId)}`),
+      fetchJSON(`${API_BASE}/api/user/get_level?user_id=${encodeURIComponent(userId)}`),
+    ])
+      .then(([user, levelResp]) => {
+        if (cancelled) return;
+        const parsed = typeof levelResp === 'string' ? JSON.parse(levelResp) : levelResp;
+        setState({
+          status: 'ready',
+          user,
+          level: parsed?.level?.subpoints ?? 0,
+          error: null,
+        });
+      })
+      .catch((error) => {
+        if (cancelled) return;
+        setState({ status: 'error', user: null, level: 0, error });
+      });
+
+    return () => {
+      cancelled = true;
+    };
+  }, [userId]);
+
+  return state;
+}

--- a/talky-app/src/Statistics/useStatsData.js
+++ b/talky-app/src/Statistics/useStatsData.js
@@ -8,13 +8,16 @@ async function fetchJSON(url) {
   return res.json();
 }
 
-// Loads the full user document plus the level subpoints in parallel.
-// Returns { status, user, level, error } where status ∈ loading|ready|error.
+const parseLevel = (resp) => {
+  const parsed = typeof resp === 'string' ? JSON.parse(resp) : resp;
+  return parsed?.level ?? null;
+};
+
 export function useStatsData(userId) {
   const [state, setState] = useState({
     status: 'loading',
     user: null,
-    level: 0,
+    level: null,
     error: null,
   });
 
@@ -27,17 +30,11 @@ export function useStatsData(userId) {
     ])
       .then(([user, levelResp]) => {
         if (cancelled) return;
-        const parsed = typeof levelResp === 'string' ? JSON.parse(levelResp) : levelResp;
-        setState({
-          status: 'ready',
-          user,
-          level: parsed?.level?.subpoints ?? 0,
-          error: null,
-        });
+        setState({ status: 'ready', user, level: parseLevel(levelResp), error: null });
       })
       .catch((error) => {
         if (cancelled) return;
-        setState({ status: 'error', user: null, level: 0, error });
+        setState({ status: 'error', user: null, level: null, error });
       });
 
     return () => {

--- a/talky-app/tests/statistics.test.js
+++ b/talky-app/tests/statistics.test.js
@@ -1,0 +1,116 @@
+import { describe, it, expect } from 'vitest';
+import {
+  computeStreak,
+  hardestWords,
+  masteryBars,
+  mostImprovedWords,
+  overallAccuracy,
+  progressSeries,
+  totalAttempts,
+} from '../src/Statistics/derive.js';
+
+const iso = (y, m, d) => new Date(Date.UTC(y, m - 1, d)).toISOString();
+
+describe('computeStreak', () => {
+  it('returns 0 for no history', () => {
+    expect(computeStreak([])).toBe(0);
+  });
+
+  it('counts consecutive days back from today', () => {
+    const today = new Date(Date.UTC(2026, 5, 9));
+    const history = [
+      { timestamp: iso(2026, 6, 9) },
+      { timestamp: iso(2026, 6, 8) },
+      { timestamp: iso(2026, 6, 7) },
+      { timestamp: iso(2026, 6, 5) },
+    ];
+    expect(computeStreak(history, today)).toBe(3);
+  });
+
+  it('ignores entries without a timestamp', () => {
+    const today = new Date(Date.UTC(2026, 5, 9));
+    expect(computeStreak([{ score: 0.5 }], today)).toBe(0);
+  });
+});
+
+describe('totalAttempts / overallAccuracy', () => {
+  const scores = [
+    { phoneme: 'r', attempts: 4, avgScore: 0.5 },
+    { phoneme: 'l', attempts: 6, avgScore: 0.8 },
+    { phoneme: 's', attempts: 0, avgScore: null },
+  ];
+
+  it('sums attempts across phonemes', () => {
+    expect(totalAttempts(scores)).toBe(10);
+  });
+
+  it('weights accuracy by attempt count', () => {
+    const acc = overallAccuracy(scores);
+    expect(acc).toBeCloseTo((4 * 0.5 + 6 * 0.8) / 10);
+  });
+
+  it('returns null when no attempts logged', () => {
+    expect(overallAccuracy([{ phoneme: 'r', attempts: 0, avgScore: null }])).toBeNull();
+  });
+});
+
+describe('hardestWords / mostImprovedWords', () => {
+  const words = [
+    { word: 'rabbit', score: 0.4, timestamp: iso(2026, 6, 1) },
+    { word: 'rabbit', score: 0.5, timestamp: iso(2026, 6, 2) },
+    { word: 'lion', score: 0.3, timestamp: iso(2026, 6, 1) },
+    { word: 'lion', score: 0.9, timestamp: iso(2026, 6, 3) },
+    { word: 'singleton', score: 0.2, timestamp: iso(2026, 6, 1) },
+  ];
+
+  it('hardestWords excludes single-attempt words', () => {
+    const result = hardestWords(words);
+    expect(result.map((w) => w.word)).not.toContain('singleton');
+  });
+
+  it('hardestWords sorts by average ascending', () => {
+    const result = hardestWords(words);
+    expect(result[0].word).toBe('rabbit');
+  });
+
+  it('mostImprovedWords reports last-minus-first delta', () => {
+    const result = mostImprovedWords(words);
+    expect(result[0].word).toBe('lion');
+    expect(result[0].value).toBeCloseTo(0.6);
+  });
+});
+
+describe('masteryBars', () => {
+  it('drops untouched phonemes and sorts weakest first', () => {
+    const bars = masteryBars([
+      { phoneme: 'r', attempts: 5, avgScore: 0.4 },
+      { phoneme: 's', attempts: 0, avgScore: null },
+      { phoneme: 'l', attempts: 2, avgScore: 0.9 },
+    ]);
+    expect(bars).toEqual([
+      { key: 'r', data: 40 },
+      { key: 'l', data: 90 },
+    ]);
+  });
+});
+
+describe('progressSeries', () => {
+  it('reads cumulative phoneme values from history dicts', () => {
+    const history = [
+      { timestamp: iso(2026, 6, 1), r: 0.2 },
+      { timestamp: iso(2026, 6, 2), r: 0.5, l: 0.1 },
+    ];
+    const series = progressSeries(history, 'r');
+    expect(series).toHaveLength(2);
+    expect(series[1].data).toBe(0.5);
+  });
+
+  it('also reads per-attempt entries shaped { phoneme, score }', () => {
+    const history = [
+      { timestamp: iso(2026, 6, 1), phoneme: 'r', score: 0.6 },
+      { timestamp: iso(2026, 6, 2), phoneme: 'l', score: 0.9 },
+    ];
+    const series = progressSeries(history, 'r');
+    expect(series).toEqual([{ key: new Date(iso(2026, 6, 1)), data: 0.6 }]);
+  });
+});


### PR DESCRIPTION
Closes #36.

Reworked the Statistics page so it actually shows what the user is doing.

What's on the page now:
- Four stat tiles up top: current level with an XP progress bar, day streak, overall accuracy, total attempts
- 90-day activity heatmap
- Per-phoneme progress area chart with a row of phoneme chips to switch sounds
- Sound mastery bar list, sorted weakest first
- Word focus card with tabs for *needs practice*, *most improved*, and *recent*

Stays on reaviz (AreaChart, BarList). Uses the existing design tokens (\`n-*\`, \`color-*\`) so it fits the rest of the app.

Data shaping lives in \`derive.js\` with a small vitest file covering the streak, totals, hardest/improved words, and progress series.

The branch also carries an earlier backend change that this page depends on: history entries get an ISO timestamp, and the lesson flow now persists per-word scores via \`updateUserProgress\`.

## Test plan
- [ ] \`npm run dev\` and open \`/statistics\` with a logged-in user
- [ ] Confirm level XP bar matches \`level.subpoints / level.maxval\`
- [ ] Click each phoneme chip — chart updates
- [ ] Switch tabs in *Word focus*